### PR TITLE
Add column name matching command

### DIFF
--- a/src/app/components/lines/edit-line-dialog/edit-line-dialog.component.css
+++ b/src/app/components/lines/edit-line-dialog/edit-line-dialog.component.css
@@ -82,3 +82,21 @@ mat-dialog-actions button {
 mat-spinner {
   margin-right: 8px;
 }
+
+/* Search button styling */
+button[matSuffix] {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+button[matSuffix]:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Ensure input has padding for the button */
+.mat-mdc-form-field-has-icon-suffix .mat-mdc-text-field-wrapper {
+  padding-right: 48px;
+}

--- a/src/app/components/lines/edit-line-dialog/edit-line-dialog.component.html
+++ b/src/app/components/lines/edit-line-dialog/edit-line-dialog.component.html
@@ -53,6 +53,15 @@
           (focus)="onColumnInputFocus()"
           (blur)="onColumnInputBlur()"
           (input)="onColumnInputChange()">
+        <button 
+          mat-icon-button 
+          matSuffix 
+          type="button"
+          (click)="findMatchingColumn()"
+          [disabled]="!editForm.get('table_name')?.value || loadingColumns()"
+          matTooltip="Find matching column based on field name">
+          <mat-icon>search</mat-icon>
+        </button>
         <mat-autocomplete
           #columnAuto="matAutocomplete"
           [displayWith]="displayColumnName"


### PR DESCRIPTION
Add a 'Find matching column' button to the edit line dialog to automatically select a column based on the line's field name.

This feature helps users quickly map a line's `field_name` to an available `column_name` in the selected table, reducing manual input and improving efficiency. It uses multiple matching strategies for robust suggestions.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfc4e330-6d54-410b-955b-02abea405f53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfc4e330-6d54-410b-955b-02abea405f53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

