### PR TITLE
feat(github): add GitHub integration with PR creation for schema-config

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -283,6 +283,23 @@
   }
 }
 
+.github-status {
+  margin-right: 8px;
+  font-size: 0.9rem;
+  opacity: 0.95;
+}
+
+.github-connect-btn {
+  margin-right: 8px;
+}
+
+.github-connect-btn mat-icon {
+  margin-right: 4px;
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
 .generate-schema-btn {
   margin-left: 16px;
   font-weight: 600;

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -69,6 +69,51 @@
       </mat-chip>
     </mat-chip-set>
 
+    <!-- GitHub status -->
+    @if (githubConnectionLoading()) {
+      <span class="github-status">GitHub: Checking…</span>
+    } @else if (githubConnected() === false) {
+      <span class="github-status">GitHub: Not connected</span>
+      <button
+        mat-button
+        (click)="openConnectGitHubDialog()"
+        class="github-connect-btn"
+        matTooltip="Connect GitHub to create pull requests"
+        matTooltipPosition="below">
+        <mat-icon>link</mat-icon>
+        Connect GitHub
+      </button>
+    } @else if (githubConnected() === true) {
+      <span class="github-status">GitHub: Connected</span>
+      <button
+        mat-icon-button
+        [matMenuTriggerFor]="githubMenu"
+        matTooltip="GitHub options"
+        matTooltipPosition="below">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #githubMenu="matMenu">
+        <button mat-menu-item (click)="openConnectGitHubDialog()">
+          <mat-icon>refresh</mat-icon>
+          <span>Update token</span>
+        </button>
+        <button mat-menu-item (click)="disconnectGithub()">
+          <mat-icon>link_off</mat-icon>
+          <span>Disconnect</span>
+        </button>
+      </mat-menu>
+    }
+
+    <button
+      mat-raised-button
+      (click)="openPushSchemaDialog()"
+      class="generate-schema-btn"
+      matTooltip="Create a pull request with schema-config.json"
+      matTooltipPosition="below">
+      <mat-icon>pin_invoke</mat-icon>
+      Push schema-config
+    </button>
+
     <button
       mat-raised-button
       color="primary"
@@ -90,8 +135,6 @@
       <mat-icon>download</mat-icon>
       Generate Schema
     </button>
-
-
   </mat-toolbar>
 
   <!-- Main Content -->

--- a/src/app/components/github/connect-github-dialog/connect-github-dialog.component.css
+++ b/src/app/components/github/connect-github-dialog/connect-github-dialog.component.css
@@ -1,0 +1,56 @@
+.connect-github-dialog {
+  min-width: 400px;
+  max-width: 90vw;
+}
+
+.hint {
+  margin: 0 0 16px 0;
+  color: #666;
+  font-size: 14px;
+}
+
+.hint code {
+  background: #f5f5f5;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.error-container {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  background-color: #ffebee;
+  border: 1px solid #f44336;
+  border-radius: 4px;
+  margin-bottom: 16px;
+}
+
+.error-container mat-icon {
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.error-container p {
+  margin: 0;
+  color: #d32f2f;
+  font-size: 14px;
+}
+
+mat-dialog-actions {
+  margin-top: 8px;
+  padding: 8px;
+  min-height: auto;
+}
+
+mat-dialog-actions button {
+  margin-left: 8px;
+}
+
+mat-dialog-actions button:first-child {
+  margin-left: 0;
+}

--- a/src/app/components/github/connect-github-dialog/connect-github-dialog.component.html
+++ b/src/app/components/github/connect-github-dialog/connect-github-dialog.component.html
@@ -1,0 +1,49 @@
+<div class="connect-github-dialog">
+  <h2 mat-dialog-title>Connect GitHub</h2>
+  <mat-dialog-content>
+    <p class="hint">Use a GitHub Personal Access Token with <code>repo</code> scope so the app can create branches and pull requests.</p>
+
+    @if (errorMessage()) {
+      <div class="error-container">
+        <mat-icon color="warn">error</mat-icon>
+        <p>{{ errorMessage() }}</p>
+      </div>
+    }
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>GitHub Personal Access Token</mat-label>
+      <input
+        matInput
+        type="password"
+        [(ngModel)]="token"
+        placeholder="ghp_..."
+        autocomplete="off"
+        [disabled]="isLoading()">
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    @if (isConnected) {
+      <button mat-button color="warn" (click)="disconnect()" [disabled]="isLoading()">
+        <mat-icon>link_off</mat-icon>
+        Disconnect
+      </button>
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="connectOrUpdate()"
+        [disabled]="!token.trim() || isLoading()">
+        <mat-icon>refresh</mat-icon>
+        Update token
+      </button>
+    } @else {
+      <button mat-raised-button color="primary" (click)="connectOrUpdate()" [disabled]="!token.trim() || isLoading()">
+        <mat-icon>link</mat-icon>
+        Connect
+      </button>
+    }
+    <button mat-button (click)="cancel()" [disabled]="isLoading()">
+      Cancel
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/components/github/connect-github-dialog/connect-github-dialog.component.ts
+++ b/src/app/components/github/connect-github-dialog/connect-github-dialog.component.ts
@@ -1,0 +1,95 @@
+import { Component, Inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule } from '@angular/forms';
+import { ApiService } from '../../../services/api.service';
+
+export interface ConnectGithubDialogData {
+  isConnected: boolean;
+}
+
+export type ConnectGithubDialogResult = { success: true } | { removed: true } | undefined;
+
+@Component({
+  selector: 'app-connect-github-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule,
+    FormsModule
+  ],
+  templateUrl: './connect-github-dialog.component.html',
+  styleUrl: './connect-github-dialog.component.css'
+})
+export class ConnectGithubDialogComponent {
+  token = '';
+  isLoading = signal(false);
+  errorMessage = signal<string | null>(null);
+
+  constructor(
+    public dialogRef: MatDialogRef<ConnectGithubDialogComponent, ConnectGithubDialogResult>,
+    @Inject(MAT_DIALOG_DATA) public data: ConnectGithubDialogData,
+    private apiService: ApiService
+  ) {}
+
+  get isConnected(): boolean {
+    return this.data.isConnected;
+  }
+
+  connectOrUpdate(): void {
+    const token = this.token.trim();
+    if (!token) {
+      this.errorMessage.set('Please enter a GitHub Personal Access Token.');
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+
+    this.apiService.setGithubConnection(token).subscribe({
+      next: () => {
+        this.isLoading.set(false);
+        this.dialogRef.close({ success: true });
+      },
+      error: (err) => {
+        this.isLoading.set(false);
+        const status = err?.status;
+        if (status === 401) {
+          this.errorMessage.set('Invalid or expired token. Please check or regenerate your token.');
+        } else if (status === 503) {
+          this.errorMessage.set('Encryption is not available. Please contact your administrator.');
+        } else {
+          this.errorMessage.set('Failed to save token. Please try again.');
+        }
+      }
+    });
+  }
+
+  disconnect(): void {
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+
+    this.apiService.deleteGithubConnection().subscribe({
+      next: () => {
+        this.isLoading.set(false);
+        this.dialogRef.close({ removed: true });
+      },
+      error: () => {
+        this.isLoading.set(false);
+        this.errorMessage.set('Failed to disconnect. Please try again.');
+      }
+    });
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/components/github/push-schema-dialog/push-schema-dialog.component.css
+++ b/src/app/components/github/push-schema-dialog/push-schema-dialog.component.css
@@ -1,0 +1,103 @@
+.push-schema-dialog {
+  min-width: 400px;
+  max-width: 90vw;
+}
+
+.push-schema-dialog mat-dialog-content {
+  padding: 24px;
+  overflow: visible;
+}
+
+.full-width {
+  width: 100%;
+  display: block;
+}
+
+.error-container {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  background-color: #ffebee;
+  border: 1px solid #f44336;
+  border-radius: 4px;
+  margin-bottom: 16px;
+}
+
+.error-container mat-icon {
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.error-container p {
+  margin: 0;
+  color: #d32f2f;
+  font-size: 14px;
+}
+
+.success-container {
+  text-align: center;
+  padding: 24px 0;
+}
+
+.success-icon {
+  font-size: 48px;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 12px;
+}
+
+.success-title {
+  margin: 0 0 12px 0;
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.pr-link {
+  display: inline-block;
+  margin-bottom: 8px;
+  word-break: break-all;
+  color: #1976d2;
+  text-decoration: none;
+}
+
+.pr-link:hover {
+  text-decoration: underline;
+}
+
+.success-detail {
+  margin: 0;
+  color: #666;
+  font-size: 14px;
+}
+
+mat-dialog-actions {
+  margin-top: 8px;
+  padding: 8px;
+  min-height: auto;
+}
+
+mat-dialog-actions button {
+  margin-left: 8px;
+}
+
+mat-dialog-actions button:first-child {
+  margin-left: 0;
+}
+
+.btn-label {
+  margin-left: 8px;
+}
+
+mat-dialog-actions mat-spinner {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+::ng-deep .mdc-button__label,.bulk-update-button ::ng-deep .mdc-button__label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  gap: 4px;
+}

--- a/src/app/components/github/push-schema-dialog/push-schema-dialog.component.html
+++ b/src/app/components/github/push-schema-dialog/push-schema-dialog.component.html
@@ -1,0 +1,64 @@
+<div class="push-schema-dialog">
+  <h2 mat-dialog-title>Push schema-config</h2>
+  <mat-dialog-content>
+    @if (hasPrResult) {
+      <div class="success-container">
+        <mat-icon color="primary" class="success-icon">check_circle</mat-icon>
+        <p class="success-title">Pull request created</p>
+        <a [href]="prResult()!.pr_url" target="_blank" rel="noopener noreferrer" class="pr-link">
+          {{ prResult()!.pr_url }}
+        </a>
+        <p class="success-detail">PR #{{ prResult()!.pr_number }} on branch {{ prResult()!.branch }}</p>
+      </div>
+    } @else {
+      @if (errorMessage()) {
+        <div class="error-container">
+          <mat-icon color="warn">error</mat-icon>
+          <p>{{ errorMessage() }}</p>
+        </div>
+      }
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Author</mat-label>
+        <input matInput [(ngModel)]="author" placeholder="e.g. Neil Matthews" [disabled]="isLoading()">
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Title</mat-label>
+        <input matInput [(ngModel)]="prTitle" placeholder="e.g. February schema sync" [disabled]="isLoading()">
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Body (optional)</mat-label>
+        <textarea matInput [(ngModel)]="prBody" rows="3" placeholder="e.g. Sync from production mapping." [disabled]="isLoading()"></textarea>
+      </mat-form-field>
+    }
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    @if (hasPrResult) {
+      <button mat-raised-button color="primary" (click)="openPr()">
+        <mat-icon>open_in_new</mat-icon>
+        Open PR
+      </button>
+      <button mat-button (click)="close()">Close</button>
+    } @else {
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="submit()"
+        [disabled]="!canSubmit || isLoading()">
+        @if (isLoading()) {
+          <mat-spinner diameter="20"></mat-spinner>
+          <span class="btn-label">Creating...</span>
+        } @else {
+          <ng-container>
+            <mat-icon>pin_invoke)?</mat-icon>
+            <span class="btn-label">Create PR</span>
+          </ng-container>
+        }
+      </button>
+      <button mat-button (click)="dialogRef.close()" [disabled]="isLoading()">Cancel</button>
+    }
+  </mat-dialog-actions>
+</div>

--- a/src/app/components/github/push-schema-dialog/push-schema-dialog.component.ts
+++ b/src/app/components/github/push-schema-dialog/push-schema-dialog.component.ts
@@ -1,0 +1,123 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { FormsModule } from '@angular/forms';
+import {
+  ApiService,
+  CreateSchemaPrBody,
+  CreateSchemaPrResponse
+} from '../../../services/api.service';
+
+export type PushSchemaDialogResult =
+  | { connectRequired: true }
+  | { updateTokenRequired: true }
+  | { prCreated: true; prUrl: string }
+  | undefined;
+
+@Component({
+  selector: 'app-push-schema-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    FormsModule
+  ],
+  templateUrl: './push-schema-dialog.component.html',
+  styleUrl: './push-schema-dialog.component.css'
+})
+export class PushSchemaDialogComponent {
+  author = '';
+  prTitle = 'Schema config update';
+  prBody = '';
+
+  isLoading = signal(false);
+  errorMessage = signal<string | null>(null);
+  prResult = signal<CreateSchemaPrResponse | null>(null);
+
+  constructor(
+    public dialogRef: MatDialogRef<PushSchemaDialogComponent, PushSchemaDialogResult>,
+    private apiService: ApiService
+  ) {}
+
+  get hasPrResult(): boolean {
+    return this.prResult() !== null;
+  }
+
+  get canSubmit(): boolean {
+    return !!(
+      this.author.trim() &&
+      this.prTitle.trim() &&
+      !this.isLoading()
+    );
+  }
+
+  submit(): void {
+    if (!this.canSubmit) return;
+
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+
+    const body: CreateSchemaPrBody = {
+      author: this.author.trim(),
+      pr_title: this.prTitle.trim()
+    };
+    const bodyText = this.prBody.trim();
+    if (bodyText) {
+      body.pr_body = bodyText;
+    }
+
+    this.apiService.createSchemaPr(body).subscribe({
+      next: (response) => {
+        this.isLoading.set(false);
+        this.prResult.set(response);
+      },
+      error: (err) => {
+        this.isLoading.set(false);
+        const status = err?.status;
+        if (status === 412) {
+          this.errorMessage.set('GitHub is not connected. Please connect GitHub first.');
+          this.dialogRef.close({ connectRequired: true });
+        } else if (status === 401) {
+          this.errorMessage.set('Your GitHub token is invalid or expired. Please update your token.');
+          this.dialogRef.close({ updateTokenRequired: true });
+        } else if (status === 404) {
+          this.errorMessage.set('Repository or base branch not found.');
+        } else if (status === 422) {
+          const msg = err?.error?.message ?? err?.error?.detail;
+          this.errorMessage.set(
+            (typeof msg === 'string' ? msg : null) ||
+              'Branch may already exist. Try again or use a different branch name.'
+          );
+        } else {
+          this.errorMessage.set('Failed to create pull request. Please try again.');
+        }
+      }
+    });
+  }
+
+  openPr(): void {
+    const result = this.prResult();
+    if (result?.pr_url) {
+      window.open(result.pr_url, '_blank');
+    }
+  }
+
+  close(): void {
+    const result = this.prResult();
+    if (result) {
+      this.dialogRef.close({ prCreated: true, prUrl: result.pr_url });
+    } else {
+      this.dialogRef.close();
+    }
+  }
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -55,6 +55,32 @@ export interface LinePatchBody {
   isfkfield?: boolean;
 }
 
+/** Response from GET /api/github-connection */
+export interface GithubConnectionResponse {
+  configured: boolean;
+}
+
+/** Response from PUT/DELETE /api/github-connection */
+export interface GithubConnectionStatusResponse {
+  status: 'configured' | 'removed';
+}
+
+/** Body for POST /api/create-schema-pr (owner, repo, file_path, branch_name, base_branch are server-configured) */
+export interface CreateSchemaPrBody {
+  author: string;
+  pr_title: string;
+  pr_body?: string;
+}
+
+/** Response from POST /api/create-schema-pr */
+export interface CreateSchemaPrResponse {
+  pr_url: string;
+  pr_number: number;
+  branch: string;
+  commit_sha: string;
+  file_path: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -257,5 +283,24 @@ export class ApiService {
 
   deleteCategoryConfig(categoryId: number): Observable<Category> {
     return this.http.delete<Category>(`${this.baseUrl}/categories/${categoryId}/config`);
+  }
+
+  // GitHub connection
+  getGithubConnection(): Observable<GithubConnectionResponse> {
+    return this.http.get<GithubConnectionResponse>(`${this.baseUrl}/github-connection`);
+  }
+
+  setGithubConnection(github_token: string): Observable<GithubConnectionStatusResponse> {
+    return this.http.put<GithubConnectionStatusResponse>(`${this.baseUrl}/github-connection`, {
+      github_token
+    });
+  }
+
+  deleteGithubConnection(): Observable<GithubConnectionStatusResponse> {
+    return this.http.delete<GithubConnectionStatusResponse>(`${this.baseUrl}/github-connection`);
+  }
+
+  createSchemaPr(body: CreateSchemaPrBody): Observable<CreateSchemaPrResponse> {
+    return this.http.post<CreateSchemaPrResponse>(`${this.baseUrl}/create-schema-pr`, body);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches token-configuration and new PR-creation flows that depend on backend auth/state and introduce new user-facing error paths; also includes a likely template typo (`mat-icon>pin_invoke)?</mat-icon>`) that could break the dialog at build/runtime.
> 
> **Overview**
> Adds a GitHub integration flow to the Angular UI: the toolbar now shows GitHub connection status with connect/update/disconnect actions, plus a new **Push schema-config** button to create a pull request for `schema-config.json`.
> 
> Introduces two new dialogs: `ConnectGithubDialogComponent` to store/update/remove a GitHub Personal Access Token (with status-specific error messaging), and `PushSchemaDialogComponent` to submit PR metadata (author/title/body), call a new API to create the PR, and display the resulting PR link/details.
> 
> Extends `ApiService` with typed endpoints for `GET/PUT/DELETE /github-connection` and `POST /create-schema-pr`, and wires `App` to fetch connection state on startup and guide users to connect/update token when PR creation fails with auth/precondition errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 635fe8e4714664f8f90d41c693dd5f9220e50630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->